### PR TITLE
Fix category container slider

### DIFF
--- a/src/pages/CompanyDetail.jsx
+++ b/src/pages/CompanyDetail.jsx
@@ -72,11 +72,11 @@ const CompanyDetail = () => {
             </div>
           </div>
         </div>
-        <div className="flex gap-4 mb-8">
+        <div className="flex gap-4 mb-8 overflow-x-auto whitespace-nowrap snap-x w-full">
           {categories.map(cat => (
             <div
               key={cat.key}
-              className={`flex flex-col items-center px-4 py-2 rounded-xl shadow cursor-pointer transition border-2 ${activeTab === cat.key ? 'border-blue-600 bg-white' : 'border-transparent bg-white/70 hover:bg-white'}`}
+              className={`flex flex-col items-center px-4 py-2 rounded-xl shadow cursor-pointer transition border-2 snap-center ${activeTab === cat.key ? 'border-blue-600 bg-white' : 'border-transparent bg-white/70 hover:bg-white'}`}
               onClick={() => setActiveTab(cat.key)}
             >
               <span className="font-semibold text-base">{cat.label}</span>


### PR DESCRIPTION
## Summary
- improve the category slider container so it scrolls horizontally
- ensure cards snap to center

## Testing
- `npm run lint` *(fails: 17 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6848aafeebc483328ad9bb6fae81a9bc