### PR TITLE
Add horizontal scroll slider for My Companies

### DIFF
--- a/src/pages/MyCompanies.jsx
+++ b/src/pages/MyCompanies.jsx
@@ -40,15 +40,17 @@ const MyCompanies = () => {
         ) : companies.length === 0 ? (
           <div className="text-gray-500">Henüz bir firma eklemediniz.</div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-            {companies.map((company) => (
-              <div key={company.id} className="bg-white rounded-2xl shadow-lg p-6 flex flex-col gap-2 hover:scale-105 transition-transform cursor-pointer" onClick={() => navigate(`/company/${company.id}`)}>
-                <div className="text-xl font-bold text-gray-800 mb-1">{company.company_name}</div>
-                <div className="text-gray-400 text-sm">Firma Kodu: {company.company_code}</div>
-                <div className="text-gray-500 text-sm">Çalışan Sayısı: {company.employee_count ?? 0}</div>
-                <div className="text-gray-400 text-xs mt-2">{company.city} / {company.district}</div>
-              </div>
-            ))}
+          <div className="overflow-x-auto">
+            <div className="inline-grid grid-flow-col auto-cols-[80%] gap-6 sm:grid grid-cols-2 md:grid-cols-3">
+              {companies.map((company) => (
+                <div key={company.id} className="w-72 bg-white rounded-2xl shadow-lg p-6 flex flex-col gap-2 hover:scale-105 transition-transform cursor-pointer" onClick={() => navigate(`/company/${company.id}`)}>
+                  <div className="text-xl font-bold text-gray-800 mb-1">{company.company_name}</div>
+                  <div className="text-gray-400 text-sm">Firma Kodu: {company.company_code}</div>
+                  <div className="text-gray-500 text-sm">Çalışan Sayısı: {company.employee_count ?? 0}</div>
+                  <div className="text-gray-400 text-xs mt-2">{company.city} / {company.district}</div>
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- wrap the companies grid with an overflow div
- use inline-grid with column flow for small screens
- give company cards a fixed width

## Testing
- `npm run lint` *(fails: several unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848ab058cd48332b3ae2c055b9f11d3