### PR TITLE
Use env vars for Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env*

--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment variables
+
+Create an `.env` file in the project root with the following keys:
+
+```bash
+VITE_SUPABASE_URL=your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+```
+

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://wyccblddborwnntxaukg.supabase.co'; // Supabase panelinden al
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Ind5Y2NibGRkYm9yd25udHhhdWtnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkzOTE2MDksImV4cCI6MjA2NDk2NzYwOX0.36RCNe7Bw0_IpYWYso9yWkWd5uYS3QCEVWfRyxzY3j8'; // Supabase panelinden al
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey); 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(process.env.VITE_SUPABASE_URL),
+    'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(process.env.VITE_SUPABASE_ANON_KEY),
+  },
 })
+


### PR DESCRIPTION
## Summary
- load Supabase credentials from environment variables
- expose the variables in `vite.config.js`
- document required `.env` keys
- ignore `.env` files

## Testing
- `npm run lint` *(fails: 'process' is not defined and unused vars)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848b04d965c8332ad986f86f8dbb8bb