### PR TITLE
Use Promise.all when counting records

### DIFF
--- a/src/pages/CompanyDetail.jsx
+++ b/src/pages/CompanyDetail.jsx
@@ -42,14 +42,20 @@ const CompanyDetail = () => {
 
   useEffect(() => {
     const fetchCounts = async () => {
-      const newCounts = {};
-      for (const cat of categories) {
+      const promises = categories.map(async (cat) => {
         const { count } = await supabase
           .from(tableMap[cat.key])
           .select('*', { count: 'exact', head: true })
           .eq('company_id', id);
-        newCounts[cat.key] = count || 0;
-      }
+        return { key: cat.key, count: count || 0 };
+      });
+
+      const results = await Promise.all(promises);
+      const newCounts = {};
+      results.forEach((res) => {
+        newCounts[res.key] = res.count;
+      });
+
       setCounts(newCounts);
     };
     if (id) fetchCounts();

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
## Summary
- fetch record counts for all company categories concurrently
- fix eslint errors in `vite.config.js`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849460afe708332bbe75644ffc9dab0