### PR TITLE
Fix missing exports

### DIFF
--- a/src/components/AssignmentModal.jsx
+++ b/src/components/AssignmentModal.jsx
@@ -186,4 +186,5 @@ const AssignmentModal = ({
   );
 };
 
+export default AssignmentModal;
 

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -355,4 +355,9 @@ const AuthPage = () => {
   );
 };
 
+// Tailwind animate-shake
+// tailwind.config.js dosyanıza ekleyin:
+// module.exports = { ... , theme: { extend: { keyframes: { shake: { '0%, 100%': { transform: 'translateX(0)' }, '20%, 60%': { transform: 'translateX(-8px)' }, '40%, 80%': { transform: 'translateX(8px)' }, }, }, }, animation: { shake: 'shake 0.5s', }, }, }, ... }
+
+export default AuthPage;
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-/* global process */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
## Summary
- restore default export in AssignmentModal
- restore default export and comment block in AuthPage
- clean up vite config lint warning

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68494bac517c8332b0633594f5897b60