### PR TITLE
Shrink dashboard cards for mobile

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -53,29 +53,29 @@ const Dashboard = () => {
             <p className="text-lg text-gray-600">({profile.user_type === 'employer' ? 'İşveren/Vekili' : 'ISG Uzmanı'})</p>
           </div>
         </div>
-        <div className="flex overflow-x-auto gap-6 mb-8 sm:grid sm:grid-cols-2 md:grid-cols-3">
+        <div className="flex overflow-x-auto gap-4 sm:gap-6 mb-8">
           {/* Raporlarım */}
           {cardData.map((card, idx) => (
-            <div key={idx} className="bg-white rounded-2xl shadow-lg p-6 flex flex-col items-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0 w-64">
+            <div key={idx} className="bg-white rounded-2xl shadow-lg p-4 flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0 w-56">
               <div className="text-4xl mb-3">{card.icon}</div>
               <h2 className="text-xl font-semibold mb-2 text-gray-800">{card.title}</h2>
               <p className="text-gray-500 text-center mb-4">{card.description}</p>
-              <button className="mt-auto px-4 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition">İncele</button>
+              <button className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition">İncele</button>
             </div>
           ))}
           {/* Firmalarım */}
-          <div className="bg-white rounded-2xl shadow-lg p-6 flex flex-col items-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0 w-64" onClick={() => navigate('/my-companies')}>
+          <div className="bg-white rounded-2xl shadow-lg p-4 flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer flex-shrink-0 w-56" onClick={() => navigate('/my-companies')}>
             <div className="text-4xl mb-3">🏢</div>
             <h2 className="text-xl font-semibold mb-2 text-gray-800">Firmalarım</h2>
             <p className="text-gray-500 text-center mb-4">Eklediğiniz tüm firmaları görüntüleyin.</p>
-            <button className="mt-auto px-4 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition">Görüntüle</button>
+            <button className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition">Görüntüle</button>
           </div>
           {/* AI Raportör */}
-          <div className="bg-gradient-to-br from-purple-500 to-indigo-600 rounded-2xl shadow-xl p-6 flex flex-col items-center hover:scale-105 transition-transform cursor-pointer text-white border-2 border-indigo-400 flex-shrink-0 w-64" onClick={() => navigate('/ai-reporter')}>
+          <div className="bg-gradient-to-br from-purple-500 to-indigo-600 rounded-2xl shadow-xl p-4 flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer text-white border-2 border-indigo-400 flex-shrink-0 w-56" onClick={() => navigate('/ai-reporter')}>
             <div className="text-5xl mb-3 animate-pulse">🤖</div>
             <h2 className="text-2xl font-bold mb-2">AI Raportör</h2>
             <p className="text-indigo-100 text-center mb-4">Yapay zeka destekli otomatik rapor oluşturucu ile tanışın.</p>
-            <button className="mt-auto px-4 py-2 bg-white text-indigo-700 rounded-lg font-semibold hover:bg-indigo-100 transition">Başlat</button>
+            <button className="px-3 py-1.5 text-sm bg-white text-indigo-700 rounded-lg font-semibold hover:bg-indigo-100 transition">Başlat</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make dashboard card layout flex-only
- reduce card dimensions and center contents
- shrink buttons to match smaller cards

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684979b92a8c8332932968ba171b8c25