### PR TITLE
Enable scrollable date picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.50.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-mobile-datepicker": "^4.0.2",
         "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
@@ -3385,6 +3386,16 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-mobile-datepicker": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/react-mobile-datepicker/-/react-mobile-datepicker-4.0.2.tgz",
+      "integrity": "sha512-B83IF3fCcq7U2Q/ZX83PUfcdaHhXpTgYXqkZW1AffOSappDtKYd7Tc1IgSBCBnON8UghWdFbj0xtnkofZsLzzw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">=0.14",
+        "react-dom": ">=0.14"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.50.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-mobile-datepicker": "^4.0.2",
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {

--- a/src/components/EmployeeDetailModal.jsx
+++ b/src/components/EmployeeDetailModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ScrollDatePicker from './ScrollDatePicker.jsx';
 import { supabase } from '../lib/supabaseClient';
 import { addYears } from '../utils';
 
@@ -153,11 +154,11 @@ const EmployeeDetailModal = ({ open, onClose, employee, dangerClass, onUpdate, a
           <div className="flex gap-2">
             <div className="w-1/2">
               <label className="block text-xs text-gray-500 mb-1">Doğum Tarihi</label>
-              <input type="date" name="birth_date" value={form.birth_date || ''} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
+              <ScrollDatePicker name="birth_date" value={form.birth_date || ''} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
             </div>
             <div className="w-1/2">
               <label className="block text-xs text-gray-500 mb-1">İşe Başlama Tarihi</label>
-              <input type="date" name="start_date" value={form.start_date || ''} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
+              <ScrollDatePicker name="start_date" value={form.start_date || ''} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
             </div>
           </div>
           <select name="gender" value={form.gender || ''} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg">
@@ -186,8 +187,7 @@ const EmployeeDetailModal = ({ open, onClose, employee, dangerClass, onUpdate, a
             <div className="flex gap-2">
               <div className="w-1/2">
                 <label className="block text-xs text-gray-500 mb-1">Sağlık Raporu Tarihi</label>
-                <input
-                  type="date"
+                <ScrollDatePicker
                   name="health_report"
                   value={form.health_report || ''}
                   onChange={handleChange}
@@ -197,11 +197,11 @@ const EmployeeDetailModal = ({ open, onClose, employee, dangerClass, onUpdate, a
               </div>
               <div className="w-1/2">
                 <label className="block text-xs text-gray-500 mb-1">Rapor Yenileme Tarihi</label>
-                <input
-                  type="date"
+                <ScrollDatePicker
                   name="report_refresh"
                   value={form.report_refresh || ''}
-                  readOnly
+                  onChange={() => {}}
+                  disabled
                   className="w-full px-3 py-2 border rounded-lg bg-gray-100"
                 />
               </div>

--- a/src/components/EmployeeModal.jsx
+++ b/src/components/EmployeeModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ScrollDatePicker from './ScrollDatePicker.jsx';
 
 const UNVAN_LIST = [
   'Çalışan', 'Yönetici', 'Müdür', 'Ekip Sorumlusu', 'Usta', 'Kalfa', 'Çırak', 'Diğer'
@@ -110,11 +111,11 @@ const EmployeeModal = ({ open, onClose, onAdd, dangerClass }) => {
           <div className="flex gap-2">
             <div className="w-1/2">
               <label className="block text-xs text-gray-500 mb-1">Doğum Tarihi</label>
-              <input type="date" name="birth_date" value={form.birth_date} onChange={handleChange} className="w-full px-3 py-2 border rounded-lg" />
+              <ScrollDatePicker name="birth_date" value={form.birth_date} onChange={handleChange} className="w-full px-3 py-2 border rounded-lg" />
             </div>
             <div className="w-1/2">
               <label className="block text-xs text-gray-500 mb-1">İşe Başlama Tarihi</label>
-              <input type="date" name="start_date" value={form.start_date} onChange={handleChange} className="w-full px-3 py-2 border rounded-lg" />
+              <ScrollDatePicker name="start_date" value={form.start_date} onChange={handleChange} className="w-full px-3 py-2 border rounded-lg" />
             </div>
           </div>
           <select name="gender" value={form.gender} onChange={handleChange} required className="w-full px-3 py-2 border rounded-lg">
@@ -142,22 +143,21 @@ const EmployeeModal = ({ open, onClose, onAdd, dangerClass }) => {
             <div className="flex gap-2">
               <div className="w-1/2">
                 <label className="block text-xs text-gray-500 mb-1">Sağlık Raporu Tarihi</label>
-                <input 
-                  type="date" 
-                  name="health_report" 
-                  value={form.health_report} 
-                  onChange={handleChange} 
-                  className="w-full px-3 py-2 border rounded-lg" 
+                <ScrollDatePicker
+                  name="health_report"
+                  value={form.health_report}
+                  onChange={handleChange}
+                  className="w-full px-3 py-2 border rounded-lg"
                 />
               </div>
               <div className="w-1/2">
                 <label className="block text-xs text-gray-500 mb-1">Rapor Yenileme Tarihi</label>
-                <input 
-                  type="date" 
-                  name="report_refresh" 
-                  value={form.report_refresh} 
-                  readOnly 
-                  className="w-full px-3 py-2 border rounded-lg bg-gray-100" 
+                <ScrollDatePicker
+                  name="report_refresh"
+                  value={form.report_refresh}
+                  onChange={() => {}}
+                  disabled
+                  className="w-full px-3 py-2 border rounded-lg bg-gray-100"
                 />
               </div>
             </div>

--- a/src/components/FireEquipmentModal.jsx
+++ b/src/components/FireEquipmentModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ScrollDatePicker from './ScrollDatePicker.jsx';
 
 const FIRE_EQUIPMENT_OPTIONS = [
   'Yangın Tüpü',
@@ -121,8 +122,7 @@ const FireEquipmentModal = ({ open, onClose, onAdd, equipment, onDelete }) => {
           </div>
           <div>
             <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Son Kontrol Tarihi</label>
-            <input
-              type="date"
+            <ScrollDatePicker
               name="last_check_date"
               value={form.last_check_date}
               onChange={handleChange}

--- a/src/components/MachineModal.jsx
+++ b/src/components/MachineModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ScrollDatePicker from './ScrollDatePicker.jsx';
 
 const MAKINE_LIST = [
   'Dikiş Makinesi',
@@ -110,7 +111,7 @@ const MachineModal = ({ open, onClose, onAdd, machine, onDelete, onUpdate }) => 
           <div className="flex gap-2">
             <div className="w-1/2">
               <label className="block text-xs text-gray-500 mb-1">Bakım Tarihi</label>
-              <input type="date" name="maintenance_date" value={form.maintenance_date} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
+              <ScrollDatePicker name="maintenance_date" value={form.maintenance_date} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
             </div>
             <div className="w-1/2">
               <label className="block text-xs text-gray-500 mb-1">Bakım Periyodu (Ay)</label>
@@ -119,7 +120,7 @@ const MachineModal = ({ open, onClose, onAdd, machine, onDelete, onUpdate }) => 
           </div>
           <div className="w-full">
             <label className="block text-xs text-gray-500 mb-1">Bakım Geçerlilik Tarihi</label>
-            <input type="date" name="maintenance_validity_date" value={form.maintenance_validity_date} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
+            <ScrollDatePicker name="maintenance_validity_date" value={form.maintenance_validity_date} onChange={handleChange} disabled={!edit} className="w-full px-3 py-2 border rounded-lg" />
           </div>
         </form>
         <div className="flex gap-4 mt-6 justify-between items-center">

--- a/src/components/PpeDeliveryModal.jsx
+++ b/src/components/PpeDeliveryModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ScrollDatePicker from './ScrollDatePicker.jsx';
 
 const PPE_OPTIONS = [
   'Baret',
@@ -223,8 +224,7 @@ const PpeDeliveryModal = ({ open, onClose, onAdd, delivery, employees, company, 
           </div>
           <div>
             <label className="block text-xs text-gray-500 mb-1">Teslim Tarihi</label>
-            <input
-              type="date"
+            <ScrollDatePicker
               name="delivery_date"
               value={form.delivery_date}
               onChange={handleChange}

--- a/src/components/ScrollDatePicker.jsx
+++ b/src/components/ScrollDatePicker.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import DatePicker from 'react-mobile-datepicker';
+
+const dateConfig = {
+  year: { format: 'YYYY', caption: 'Yıl', step: 1 },
+  month: { format: 'MM', caption: 'Ay', step: 1 },
+  date: { format: 'DD', caption: 'Gün', step: 1 }
+};
+
+const ScrollDatePicker = ({ name, value, onChange, disabled, className }) => {
+  const [open, setOpen] = useState(false);
+  const handleSelect = (time) => {
+    setOpen(false);
+    onChange({ target: { name, value: time.toISOString().slice(0, 10) } });
+  };
+  const handleCancel = () => setOpen(false);
+
+  return (
+    <>
+      <input
+        type="text"
+        name={name}
+        value={value}
+        readOnly
+        disabled={disabled}
+        className={className}
+        onClick={() => !disabled && setOpen(true)}
+      />
+      <DatePicker
+        theme="ios"
+        isOpen={open}
+        dateConfig={dateConfig}
+        value={value ? new Date(value) : new Date()}
+        onSelect={handleSelect}
+        onCancel={handleCancel}
+        confirmText="Tamam"
+        cancelText="İptal"
+      />
+    </>
+  );
+};
+
+export default ScrollDatePicker;


### PR DESCRIPTION
## Summary
- add `react-mobile-datepicker` dependency
- create reusable `ScrollDatePicker` component
- use `ScrollDatePicker` in employee, machine, fire equipment and PPE modals

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849932e87108332b69e1228bb42368c